### PR TITLE
Add support for ARM64

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -96,8 +96,8 @@
       -->
       <PreprocessorDefinitions>WIN32;_WINDOWS;WIN32_LEAN_AND_MEAN;NOMINMAX;_CA_SHOULD_CHECK_RETURN;_CA_SHOULD_CHECK_RETURN_WER;__STDC_WANT_SECURE_LIB__=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
 
-      <!-- Mark the application compatible with Control-flow Enforcement Technology (CET) Shadow Stack -->
-      <CETCompat>true</CETCompat>
+      <!-- Mark the application compatible with Control-flow Enforcement Technology (CET) Shadow Stack (for x86 and x64)-->
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
 
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)generate-header-units;$(MSBuildThisFileDirectory)wtl\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/WICExplorer.sln
+++ b/WICExplorer.sln
@@ -8,6 +8,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EFF3E912-976A-4266-B528-B581BADE34A3}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
+		default.ruleset = default.ruleset
+		default.ruleset.md = default.ruleset.md
 		description.html = description.html
 		Directory.Build.props = Directory.Build.props
 		license.rtf = license.rtf
@@ -18,24 +20,34 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GenerateHeaderUnits", "gene
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|ARM64 = Debug|ARM64
 		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|ARM64 = Release|ARM64
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Debug|ARM64.Build.0 = Debug|ARM64
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Debug|x64.ActiveCfg = Debug|x64
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Debug|x64.Build.0 = Debug|x64
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Debug|x86.ActiveCfg = Debug|Win32
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Debug|x86.Build.0 = Debug|Win32
+		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Release|ARM64.ActiveCfg = Release|ARM64
+		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Release|ARM64.Build.0 = Release|ARM64
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Release|x64.ActiveCfg = Release|x64
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Release|x64.Build.0 = Release|x64
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Release|x86.ActiveCfg = Release|Win32
 		{68ED6FAE-290E-483A-8D90-6E59BAFBC3C9}.Release|x86.Build.0 = Release|Win32
+		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Debug|ARM64.Build.0 = Debug|ARM64
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Debug|x64.ActiveCfg = Debug|x64
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Debug|x64.Build.0 = Debug|x64
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Debug|x86.ActiveCfg = Debug|Win32
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Debug|x86.Build.0 = Debug|Win32
+		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Release|ARM64.ActiveCfg = Release|ARM64
+		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Release|ARM64.Build.0 = Release|ARM64
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Release|x64.ActiveCfg = Release|x64
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Release|x64.Build.0 = Release|x64
 		{7B23FCCF-1559-426D-AE55-95D0D6BD352B}.Release|x86.ActiveCfg = Release|Win32

--- a/default.ruleset.md
+++ b/default.ruleset.md
@@ -1,14 +1,14 @@
 ﻿# Comments on disabled Microsoft C++ Code Analysis Rules
 
-This document contains the rationales why Microsoft
+This document contains the rationales why some Microsoft
 C++ warnings are disabled in the file default.ruleset
 It is not possible to add this info to the .ruleset file itself as edit actions
 with the VS GUI would cause the comments to get lost.
-Most of these rules\warning are based on the C++ Core Guidelines.
+Most of these Microsoft rules\warning are based on the C++ Core Guidelines.
 
 ## Warnings
 
-- C26052: Potentially unconstrained access using expression
+- C26052: Potentially unconstrained access using expression  
 **Rationale**: false warnings (VS 2019 16.9.0 Preview 2)
 
 - C26429: Use a not_null to indicate that "null" is not a valid value  
@@ -37,11 +37,11 @@ gsl::span and pass as a span iterator (stl.1)
 **Rationale**: static analysis can verify access.
 
 - C26485: Do not pass an array as a single pointer  
-**Rationale**: see C26481.
+**Rationale**: see rationale for C26481.
 
 - C26490: Don't use reinterpret_cast  
-**Rationale**: required to work with win32 API, manual verification required.
+**Rationale**: required to work with win32 API, manual review required.
 
 - C26494: Variable 'x' is uninitialized. Always initialize an object  
-**Rationale**: many false warnings due to output parameters. Other analyzers are better 
-as they check if the variable is used before initialized.
+**Rationale**: many false warnings due to output parameters. Other analyzers (prefast) provide
+flow inspection and can be used.

--- a/generate-header-units/GenerateHeaderUnits.vcxproj
+++ b/generate-header-units/GenerateHeaderUnits.vcxproj
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -29,14 +37,12 @@
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <ConfigurationType>StaticLibrary</ConfigurationType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -51,7 +57,13 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -60,14 +72,12 @@
       <ScanSourceForModuleDependencies>true</ScanSourceForModuleDependencies>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" />
   <ItemGroup>
     <ClInclude Include="std.h" />
     <ClInclude Include="Windows-import.h" />

--- a/src/WICExplorer.vcxproj
+++ b/src/WICExplorer.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|ARM64">
+      <Configuration>Debug</Configuration>
+      <Platform>ARM64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
       <Platform>Win32</Platform>
@@ -8,6 +12,10 @@
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|ARM64">
+      <Configuration>Release</Configuration>
+      <Platform>ARM64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
@@ -30,14 +38,12 @@
   <PropertyGroup>
     <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'" Label="Configuration" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -51,10 +57,16 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -73,6 +85,14 @@
       <AdditionalManifestFiles>app.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
     </Manifest>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
+    <Link>
+      <AdditionalDependencies>windowscodecs.lib;Mscms.lib;comsupp.lib;Onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <Manifest>
+      <AdditionalManifestFiles>app.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <Link>
       <AdditionalDependencies>windowscodecs.lib;Mscms.lib;comsupp.lib;Onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -84,6 +104,15 @@
     </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Link>
+      <AdditionalDependencies>windowscodecs.lib;Mscms.lib;comsupp.lib;Onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <Manifest>
+      <AdditionalManifestFiles>app.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <Link>
       <AdditionalDependencies>windowscodecs.lib;Mscms.lib;comsupp.lib;Onecore.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
@@ -118,7 +147,9 @@
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</MultiProcessorCompilation>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</MultiProcessorCompilation>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</MultiProcessorCompilation>
+      <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">false</MultiProcessorCompilation>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</MultiProcessorCompilation>
+      <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">false</MultiProcessorCompilation>
     </ClCompile>
     <ClCompile Include="OutputDevice.cpp" />
     <ClCompile Include="PropVariant.cpp" />


### PR DESCRIPTION
To be able to test and verify native ARM64 WIC components make it possible to build WICExplorer in ARM64 mode.
Running this architecture requires Windows 11 for ARM64