### PR TITLE
Fix build problems and force usage of MSVC Toolset 14.34.31933

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,9 @@
 
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)default.ruleset</CodeAnalysisRuleSet>
     <CAExcludePath>$(IntDir);$(MSBuildThisFileDirectory)wtl\include</CAExcludePath>
+
+    <!-- Newer versions of Visual Studio (17.5 and 17.6 Preview 2.0 have known defects and fail to compile WICExplorer. -->
+    <VCToolsVersion>14.34.31933</VCToolsVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) Microsoft Corporation
+Copyright (c) 2021 Victor Derks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/generate-header-units/GenerateHeaderUnits.cpp
+++ b/generate-header-units/GenerateHeaderUnits.cpp
@@ -1,4 +1,3 @@
 ﻿
 import <std.h>;
 import <Windows-import.h>;
-import <strsafe.h>;

--- a/src/CodeGenerator.ixx
+++ b/src/CodeGenerator.ixx
@@ -6,15 +6,10 @@
 //
 // Copyright (c) Microsoft Corporation. All rights reserved.
 //----------------------------------------------------------------------------------------
-module;
-
-#include "Macros.h"
-
 export module CodeGenerator;
 
 import ICodeGenerator;
 
-import <strsafe.h>;
 import <std.h>;
 
 
@@ -24,7 +19,7 @@ public:
     CSimpleCodeGenerator() noexcept(false)
     {
         BeginVariable(L"IWICImagingFactory*", L"imagingFactory", L"nullptr");
-        CallFunction(L"CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_IWICImagingFactory, (LPVOID*) &imagingFactory)");
+        CallFunction(L"CoCreateInstance(CLSID_WICImagingFactory, nullptr, CLSCTX_INPROC_SERVER, IID_IWICImagingFactory, (LPVOID*) &imagingFactory);");
     }
 
     void BeginVariableScope(std::wstring_view varType, std::wstring_view varBaseName, std::wstring_view varInitValue) override
@@ -46,26 +41,9 @@ public:
         }
     }
 
-    void CallFunction(const wchar_t* func, ...) override
+    void CallFunction(const std::wstring& func) override
     {
-        constexpr size_t maxCallLength = 1024;
-        wchar_t call[maxCallLength];
-
-        WARNING_SUPPRESS_NEXT_LINE(26826) //  Don't use C-style variable arguments (f.55).
-        va_list args;
-
-        WARNING_SUPPRESS_NEXT_LINE(26826) //  Don't use C-style variable arguments (f.55).
-        WARNING_SUPPRESS_NEXT_LINE(26492) // Don't use const_cast to cast away const or volatile (type.3).
-        va_start(args, func);
-
-        StringCchVPrintf(call, maxCallLength, func, args);
-
-        WARNING_SUPPRESS_NEXT_LINE(26826) //  Don't use C-style variable arguments (f.55).
-        va_end(args);
-
-        StringCchCatW(call, maxCallLength, L";");
-
-        AddLine(call);
+        AddLine(func);
     }
 
     const std::wstring& GetLastVariableName() noexcept override
@@ -90,7 +68,7 @@ private:
     {
 #pragma warning(push)
 #pragma warning(disable : 4296) // '<': expression is always false (known defect in MSVC compiler 2022 17.4 Preview 1.0)
-        AddLine(std::format(L"{} {} = {}", varType, varBaseName, varInitValue));
+        AddLine(std::format(L"{} {} = {};", varType, varBaseName, varInitValue));
 #pragma warning(pop)
 
         m_lastVarName = varBaseName;

--- a/src/Element.ixx
+++ b/src/Element.ixx
@@ -9,6 +9,8 @@
 module;
 
 #include <atlstr.h>
+
+#include "Macros.h"
 #include "ComSmartPointers.h"
 
 export module Element;
@@ -16,6 +18,8 @@ export module Element;
 import ImageTransencoder;
 import IOutputDevice;
 import ICodeGenerator;
+
+import <std.h>;
 
 export HRESULT GetPixelFormatName(wchar_t* dest, uint32_t chars, WICPixelFormatGUID guid);
 
@@ -38,7 +42,7 @@ public:
     CInfoElement& operator=(const CInfoElement&) = default;
     CInfoElement& operator=(CInfoElement&&) = default;
 
-    [[nodiscard]] const ATL::CString& Name() const noexcept
+    [[nodiscard]] const std::wstring& Name() const noexcept
     {
         return m_name;
     }
@@ -135,7 +139,7 @@ public:
     ATL::CString m_queryValue;
 
 protected:
-    ATL::CString   m_name;
+    std::wstring m_name;
 
 private:
     void Unlink() noexcept;
@@ -193,10 +197,10 @@ public:
         : CComponentInfoElement(filename)
         , m_filename(filename)
     {
-        const int pathDelim = m_name.ReverseFind('\\');
-        if (pathDelim >= 0)
+        const size_t pathDelim{m_name.rfind(L'\\')};
+        if (pathDelim != std::wstring::npos)
         {
-            m_name = m_name.Right(m_name.GetLength() - pathDelim - 1);
+            m_name = m_name.substr(pathDelim + 1);
         }
     }
 
@@ -261,7 +265,8 @@ public:
         : CBitmapSourceElement(L"", frameDecode)
         , m_frameDecode(frameDecode)
     {
-        m_name.Format(L"Frame #%u", index);
+        WARNING_SUPPRESS_NEXT_LINE(4296) // '<': expression is always false
+        m_name = std::format(L"Frame #{}", index);
     }
 
     HRESULT SaveAsImage(CImageTransencoder& trans, ICodeGenerator& codeGen) noexcept(false) override;

--- a/src/ICodeGenerator.ixx
+++ b/src/ICodeGenerator.ixx
@@ -8,7 +8,7 @@ export struct ICodeGenerator
 
     virtual void BeginVariableScope(std::wstring_view varType, std::wstring_view varBaseName, std::wstring_view varInitValue) = 0;
     virtual void EndVariableScope() = 0;
-    virtual void CallFunction(const wchar_t* func, ...) = 0;
+    virtual void CallFunction(const std::wstring& func) = 0;
     virtual const std::wstring& GetLastVariableName() noexcept = 0;
     virtual std::wstring GenerateCode() = 0;
 

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -244,7 +244,7 @@ HTREEITEM CMainFrame::BuildTree(const CInfoElement* elem, const HTREEITEM hParen
         const uint32_t state = (nullptr == hParent) ? TVIS_BOLD : 0;
 
         const HTREEITEM hItem = m_mainTree.InsertItem(TVIF_TEXT | TVIF_STATE | TVIF_IMAGE | TVIF_SELECTEDIMAGE,
-                                                      elem->Name(), image, image, state, state, 0, hParent, nullptr);
+                                                      elem->Name().c_str(), image, image, state, state, 0, hParent, nullptr);
 
         // Set a pointer to the element in the tree
         m_mainTree.SetItemData(hItem, reinterpret_cast<DWORD_PTR>(elem));
@@ -612,7 +612,7 @@ void CMainFrame::DrawElement(CInfoElement& element)
     m_infoEdit.ReplaceSel(L"");
 
     // Display the view -- prepend it with a path to the selected element
-    CString path = element.Name();
+    auto path{element.Name()};
     CInfoElement* parent = &element;
 
     while (nullptr != parent->Parent())
@@ -622,7 +622,7 @@ void CMainFrame::DrawElement(CInfoElement& element)
     }
 
     CRichEditDevice view(m_viewEdit);
-    view.BeginSection(path);
+    view.BeginSection(path.c_str());
     element.OutputView(view, m_viewcontext);
     view.EndSection();
 
@@ -761,15 +761,13 @@ HRESULT CMainFrame::SaveElementAsImage(CInfoElement& element)
 
                 if (FAILED(result))
                 {
-                    CString msg;
-                    msg.Format(L"Unable to encode '%s' as '%s'. The error is: %s.\n\n",
-                        element.Name().GetString(), fileDlg.m_szFileName, GetHresultString(result).c_str());
-
-                    msg += codeGen.GenerateCode().c_str();
+                    auto msg{std::format(L"Unable to encode '{}' as '{}'. The error is: {}.\n\n",
+                        element.Name(), fileDlg.m_szFileName, GetHresultString(result))};
+                    msg += codeGen.GenerateCode();
 
                     if (!m_suppressMessageBox)
                     {
-                        MessageBoxW(msg, L"Error Encoding Image", MB_OK | MB_ICONERROR);
+                        MessageBoxW(msg.c_str(), L"Error Encoding Image", MB_OK | MB_ICONERROR);
                     }
                 }
                 else if (dlg.GetPixelFormat() != GUID_WICPixelFormatDontCare &&
@@ -805,7 +803,7 @@ HRESULT CMainFrame::SaveElementAsImage(CInfoElement& element)
     else
     {
         CString msg;
-        msg.Format(L"The selected element '%s' cannot be saved as an Image.", element.Name().GetString());
+        msg.Format(L"The selected element '%s' cannot be saved as an Image.", element.Name().c_str());
 
         if (!m_suppressMessageBox)
         {

--- a/src/PropVariant.cpp
+++ b/src/PropVariant.cpp
@@ -19,8 +19,6 @@ import <std.h>;
 
 import <Windows-import.h>;
 
-import <strsafe.h>;
-
 namespace {
 
 template<class T> static void WriteValue(const T & /*val*/, CString &out)
@@ -118,9 +116,10 @@ template<> void WriteValue<LARGE_INTEGER>(const LARGE_INTEGER &val, CString &out
     // "the numerator in low part and denominator in the high part"
     if (0 != val.HighPart)
     {
-        wchar_t str[64];
-        StringCchPrintfW(str, 64, L"%ul / %dl (%g)", val.LowPart, val.HighPart, static_cast<double>(val.LowPart) / static_cast<double>(val.HighPart));
-        out = str;
+#pragma warning(push)
+#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, solved in VS 2022, 17.5, but 17.5 has critical flaw in named modules]
+        out = std::format(L"{} / {} ({})", val.LowPart, val.HighPart, static_cast<double>(val.LowPart) / static_cast<double>(val.HighPart)).c_str();
+#pragma warning(pop)
     }
     else
     {
@@ -138,9 +137,10 @@ template<> void WriteValue<ULARGE_INTEGER>(const ULARGE_INTEGER &val, CString &o
     // "the numerator in low part and denominator in the high part"
     if (0 != val.HighPart)
     {
-        wchar_t str[64];
-        StringCchPrintfW(str, 64, L"%u / %u (%g)", val.LowPart, val.HighPart, static_cast<double>(val.LowPart) / static_cast<double>(val.HighPart));
-        out = str;
+#pragma warning(push)
+#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, solved in VS 2022, 17.5, but 17.5 has critical flaw in named modules]
+        out = std::format("{} / {} ({})", val.LowPart, val.HighPart, static_cast<double>(val.LowPart) / static_cast<double>(val.HighPart)).c_str();
+#pragma warning(pop)
     }
     else
     {
@@ -155,9 +155,9 @@ template<> PCWSTR GetTypeName<ULARGE_INTEGER>() noexcept
 
 template<> void WriteValue<FLOAT>(const FLOAT &val, CString &out)
 {
-    wchar_t str[64];
-    StringCchPrintfW(str, 64, L"%g", static_cast<double>(val));
-    out = str;
+    //wchar_t str[64];
+    //StringCchPrintfW(str, 64, L"%g", static_cast<double>(val));
+    out = std::to_wstring(val).c_str();
 }
 
 template<> PCWSTR GetTypeName<FLOAT>() noexcept
@@ -167,9 +167,10 @@ template<> PCWSTR GetTypeName<FLOAT>() noexcept
 
 template<> void WriteValue<DOUBLE>(const DOUBLE &val, CString &out)
 {
-    wchar_t str[64];
-    StringCchPrintfW(str, 64, L"%g", val);
-    out = str;
+    //wchar_t str[64];
+    //StringCchPrintfW(str, 64, L"%g", val);
+    //out = str;
+    out = std::to_wstring(val).c_str();
 }
 
 template<> PCWSTR GetTypeName<DOUBLE>() noexcept

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,7 +1,6 @@
 ﻿module Util;
 
 import <std.h>;
-import <strsafe.h>;
 import <Windows-import.h>;
 
 using std::array;
@@ -93,11 +92,11 @@ std::wstring GetHresultString(HRESULT hr)
         {
             msg[len - 1] = L'\0';
         }
-    }
-    else
-    {
-        StringCchPrintf(msg, MAX_MsgLength, L"0x%.8X", static_cast<unsigned>(hr));
+        return msg;
     }
 
-    return msg;
+#pragma warning(push)
+#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, solved in VS 2022, 17.5, but 17.5 has critical flaw in named modules]
+    return std::format(L"{:#8X}", hr);
+#pragma warning(pop)
 }

--- a/src/ViewInstalledCodecsDlg.cpp
+++ b/src/ViewInstalledCodecsDlg.cpp
@@ -24,7 +24,7 @@ LRESULT CViewInstalledCodecsDlg::OnInitDialog(uint32_t /*uMsg*/, WPARAM /*wParam
 
     {
         IEnumUnknownPtr e;
-        HRESULT result = g_imagingFactory->CreateComponentEnumerator(WICEncoder, WICComponentEnumerateRefresh, &e);
+        const HRESULT result{g_imagingFactory->CreateComponentEnumerator(WICEncoder, WICComponentEnumerateRefresh, &e)};
         if (SUCCEEDED(result))
         {
             ULONG num;
@@ -49,7 +49,7 @@ LRESULT CViewInstalledCodecsDlg::OnInitDialog(uint32_t /*uMsg*/, WPARAM /*wParam
 
     {
         IEnumUnknownPtr e;
-        HRESULT result = g_imagingFactory->CreateComponentEnumerator(WICDecoder, WICComponentEnumerateRefresh, &e);
+        const HRESULT result{g_imagingFactory->CreateComponentEnumerator(WICDecoder, WICComponentEnumerateRefresh, &e)};
         if (SUCCEEDED(result))
         {
             ULONG num;


### PR DESCRIPTION
Visual Studio 2022 17.4 (14.34.31933) can correctly build the application. Newer versions fail to compile ATL headers. (__try\__catch defect)

- Remove usage of <strsafe.h> by using std::format. (Visual Studio 2022 17.6 Preview 2.0 fails to compile strsafe.h Use std::format at the calling side as this allows compile time verification of the passed arguments. With strsafe.h removed VS 2022 17.6 can build (with build messages), but generated .exe doesn't run.