### PR TITLE
Add the option to normalizing the histogram of 16 bit grayscale images

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,3 +46,10 @@ The right hand pane displays the contents of the currently highlighted node. Thi
 ### Saving to another image format
 
 WIC Explorer can save an image to any supported WIC encoder; you can also specify the desired pixel format in which to save. Note that not all of the listed pixel formats may be supported by the encoder; it will automatically perform pixel format conversion when necessary. It also will not preserve any metadata in the original image.
+
+### Normalizing the histogram of 16 bit grayscale images
+
+WIC Explorer can normalize the histogram of 16 bit grayscale images.
+This is useful for images that have a very small range of values, as it will stretch the histogram to fill the entire range.
+Typically this is used for medical images, such as exported DICOM images.
+This option is enabled by default, but can be disabled in the view menu.

--- a/src/ComSmartPointers.h
+++ b/src/ComSmartPointers.h
@@ -12,6 +12,8 @@
 _COM_SMARTPTR_TYPEDEF(IWICImagingFactory, __uuidof(IWICImagingFactory));
 _COM_SMARTPTR_TYPEDEF(IWICBitmapDecoder, __uuidof(IWICBitmapDecoder));
 _COM_SMARTPTR_TYPEDEF(IWICBitmapSource, __uuidof(IWICBitmapSource));
+_COM_SMARTPTR_TYPEDEF(IWICBitmap, __uuidof(IWICBitmap));
+_COM_SMARTPTR_TYPEDEF(IWICBitmapLock, __uuidof(IWICBitmapLock));
 _COM_SMARTPTR_TYPEDEF(IWICBitmapFrameDecode, __uuidof(IWICBitmapFrameDecode));
 _COM_SMARTPTR_TYPEDEF(IWICMetadataReader, __uuidof(IWICMetadataReader));
 

--- a/src/Element.ixx
+++ b/src/Element.ixx
@@ -21,6 +21,7 @@ export extern IWICImagingFactoryPtr g_imagingFactory;
 export struct InfoElementViewContext
 {
     bool bIsAlphaEnable;
+    bool normalizeHistogram;
 };
 
 export class CInfoElement

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -1007,6 +1007,27 @@ LRESULT CMainFrame::OnShowInstalledCodecs(uint16_t, uint16_t, HWND, BOOL&)
     return 0;
 }
 
+LRESULT CMainFrame::OnNormalizeHistogram(uint16_t /*code*/, uint16_t item, HWND /*hSender*/, BOOL& handled) noexcept
+{
+    const HMENU menu{GetMenu()};
+    MENUITEMINFO currentState{.cbSize = sizeof currentState, .fMask = MIIM_STATE};
+
+    GetMenuItemInfo(menu, item, false, &currentState);
+    if ((currentState.fState & MFS_CHECKED) == MFS_CHECKED)
+    {
+        m_viewcontext.normalizeHistogram = false;
+        CheckMenuItem(menu, item, MF_UNCHECKED | MF_BYCOMMAND);
+    }
+    else
+    {
+        m_viewcontext.normalizeHistogram = true;
+        CheckMenuItem(menu, item, MF_CHECKED | MF_BYCOMMAND);
+        handled = 1;
+    }
+
+    return 0;
+}
+
 LRESULT CMainFrame::OnContextClick(const uint16_t /*code*/, const uint16_t item, HWND /*hSender*/, BOOL& handled)
 {
     handled = true;

--- a/src/MainFrame.h
+++ b/src/MainFrame.h
@@ -35,6 +35,7 @@ public:
         COMMAND_ID_HANDLER(ID_SHOW_VIEWPANE, OnShowViewPane)
         COMMAND_ID_HANDLER(ID_SHOW_ALPHA, OnShowAlpha)
         COMMAND_ID_HANDLER(ID_SHOW_INSTALLED_CODECS, OnShowInstalledCodecs)
+        COMMAND_ID_HANDLER(ID_VIEW_NORMALIZE_HISTOGRAM, OnNormalizeHistogram)
         COMMAND_ID_HANDLER(ID_FILE_LOAD, OnContextClick)
         COMMAND_ID_HANDLER(ID_FILE_UNLOAD, OnContextClick)
         COMMAND_ID_HANDLER(ID_FILE_CLOSE, OnContextClick)
@@ -52,7 +53,7 @@ public:
     HRESULT Load(const LPCWSTR *filenames, int count);
 
 private:
-    InfoElementViewContext m_viewcontext{};
+    InfoElementViewContext m_viewcontext{false, true};
 
     HWND CreateClient();
     static int GetElementTreeImage(const CInfoElement *elem) noexcept;
@@ -86,6 +87,7 @@ private:
     LRESULT OnShowViewPane(uint16_t code, uint16_t item, HWND hSender, BOOL& handled);
     LRESULT OnShowAlpha(uint16_t code, uint16_t item, HWND hSender, BOOL& handled);
     static LRESULT OnShowInstalledCodecs(uint16_t, uint16_t, HWND, BOOL&);
+    LRESULT OnNormalizeHistogram(uint16_t code, uint16_t item, HWND hSender, BOOL& handled) noexcept;
     LRESULT OnContextClick(uint16_t code, uint16_t item, HWND hSender, BOOL& handled);
 
     CSplitterWindow m_mainSplit;

--- a/src/WICExplorer.rc
+++ b/src/WICExplorer.rc
@@ -89,6 +89,7 @@ BEGIN
         MENUITEM "Show Alpha",                  ID_SHOW_ALPHA, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "Installed WIC Codecs",        ID_SHOW_INSTALLED_CODECS
+        MENUITEM "Normalize Histogram (16 bit grayscale)", ID_VIEW_NORMALIZE_HISTOGRAM, CHECKED
     END
     POPUP "&Help"
     BEGIN

--- a/src/resource.h
+++ b/src/resource.h
@@ -22,13 +22,14 @@
 #define ID_FIND_METADATA                32776
 #define ID_SHOW_ALPHA                   32777
 #define ID_SHOW_INSTALLED_CODECS        32778
+#define ID_VIEW_NORMALIZE_HISTOGRAM     32779
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
 #define _APS_NEXT_RESOURCE_VALUE        207
-#define _APS_NEXT_COMMAND_VALUE         32778
+#define _APS_NEXT_COMMAND_VALUE         32780
 #define _APS_NEXT_CONTROL_VALUE         1007
 #define _APS_NEXT_SYMED_VALUE           101
 #endif


### PR DESCRIPTION
Some medical grayscale images (DICOM) are using 16 bit, but using only a small dynamic range.
The default Windows display pipeline will make these images very dark. Add a helper method to use the full range of the 16 bit pixel value range.