### PR TITLE
Remove FAR from pointers

### DIFF
--- a/src/CodeGenerator.ixx
+++ b/src/CodeGenerator.ixx
@@ -61,11 +61,7 @@ public:
 private:
     void BeginVariable(std::wstring_view varType, std::wstring_view varBaseName, std::wstring_view varInitValue)
     {
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false (known defect in MSVC compiler 2022 17.4 Preview 1.0)
         AddLine(std::format(L"{} {} = {};", varType, varBaseName, varInitValue));
-#pragma warning(pop)
-
         m_lastVarName = varBaseName;
     }
 

--- a/src/Element.cpp
+++ b/src/Element.cpp
@@ -239,7 +239,7 @@ private:
 
 IWICImagingFactoryPtr g_imagingFactory;
 
-CInfoElement::CInfoElement(const LPCWSTR name)
+CInfoElement::CInfoElement(const PCWSTR name)
     : m_name{name}
 {
 
@@ -335,7 +335,7 @@ void CInfoElement::RemoveChild(CInfoElement* child) noexcept
     delete child;
 }
 
-HRESULT CElementManager::OpenFile(const LPCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem)
+HRESULT CElementManager::OpenFile(const PCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem)
 {
     HRESULT result = E_UNEXPECTED;
 
@@ -474,7 +474,7 @@ HRESULT CBitmapDecoderElement::Load(ICodeGenerator& codeGen)
     return (FAILED(lastFailResult)) ? lastFailResult : result;
 }
 
-HRESULT CElementManager::CreateDecoderAndChildElements(const LPCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem)
+HRESULT CElementManager::CreateDecoderAndChildElements(const PCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem)
 {
     decElem = std::make_unique<CBitmapDecoderElement>(filename).release();
     const HRESULT result = (static_cast<CBitmapDecoderElement*>(decElem)->Load(codeGen));
@@ -674,7 +674,7 @@ CInfoElement* CElementManager::GetRootElement() noexcept
     return &root;
 }
 
-HRESULT CElementManager::SaveElementAsImage(CInfoElement& element, REFGUID containerFormat, WICPixelFormatGUID& format, const LPCWSTR filename, ICodeGenerator& codeGen)
+HRESULT CElementManager::SaveElementAsImage(CInfoElement& element, REFGUID containerFormat, WICPixelFormatGUID& format, const PCWSTR filename, ICodeGenerator& codeGen)
 {
     HRESULT result;
 
@@ -853,24 +853,24 @@ void CBitmapDecoderElement::FillContextMenu(const HMENU context) noexcept
     {
         itemInfo.wID = ID_FILE_SAVE;
         WARNING_SUPPRESS_NEXT_LINE(26465 26492) // Don't use const_cast to cast away const or volatile.
-            itemInfo.dwTypeData = const_cast<LPWSTR>(L"Save As Image...");
+            itemInfo.dwTypeData = const_cast<PWSTR>(L"Save As Image...");
         VERIFY(InsertMenuItem(context, GetMenuItemCount(context), true, &itemInfo));
 
         itemInfo.wID = ID_FILE_UNLOAD;
         WARNING_SUPPRESS_NEXT_LINE(26465 26492) // Don't use const_cast to cast away const or volatile.
-            itemInfo.dwTypeData = const_cast<LPWSTR>(L"Unload");
+            itemInfo.dwTypeData = const_cast<PWSTR>(L"Unload");
     }
     else
     {
         itemInfo.wID = ID_FILE_LOAD;
         WARNING_SUPPRESS_NEXT_LINE(26465 26492) // Don't use const_cast to cast away const or volatile.
-            itemInfo.dwTypeData = const_cast<LPWSTR>(L"Load");
+            itemInfo.dwTypeData = const_cast<PWSTR>(L"Load");
     }
     VERIFY(InsertMenuItem(context, GetMenuItemCount(context), true, &itemInfo));
 
     itemInfo.wID = ID_FILE_CLOSE;
     WARNING_SUPPRESS_NEXT_LINE(26465 26492) // Don't use const_cast to cast away const or volatile.
-        itemInfo.dwTypeData = const_cast<LPWSTR>(L"Close");
+        itemInfo.dwTypeData = const_cast<PWSTR>(L"Close");
     VERIFY(InsertMenuItem(context, GetMenuItemCount(context), true, &itemInfo));
 }
 
@@ -1005,7 +1005,7 @@ void CBitmapDecoderElement::SetCreationTime(const DWORD ms) noexcept
     m_creationTime = ms;
 }
 
-void CBitmapDecoderElement::SetCreationCode(const LPCWSTR code)
+void CBitmapDecoderElement::SetCreationCode(const PCWSTR code)
 {
     m_creationCode = code;
 }
@@ -1197,11 +1197,8 @@ HRESULT CBitmapSourceElement::OutputView(IOutputDevice& output, const InfoElemen
         }
         else
         {
-            const COLORREF oldColor = output.SetTextColor(RGB(255, 0, 0));
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
+            const COLORREF oldColor{output.SetTextColor(RGB(255, 0, 0))};
             output.AddText(std::format(L"Failed to convert IWICBitmapSource to HBITMAP: {}", GetHresultString(result)).c_str());
-#pragma warning(pop)
             output.SetTextColor(oldColor);
         }
     }

--- a/src/Element.ixx
+++ b/src/Element.ixx
@@ -27,7 +27,7 @@ export struct InfoElementViewContext
 export class CInfoElement
 {
 public:
-    explicit CInfoElement(LPCWSTR name);
+    explicit CInfoElement(PCWSTR name);
     virtual ~CInfoElement();
 
     CInfoElement() = delete;
@@ -152,7 +152,7 @@ private:
 export class CElementManager
 {
 public:
-    static HRESULT OpenFile(LPCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem);
+    static HRESULT OpenFile(PCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem);
 
     static void RegisterElement(CInfoElement* element)  noexcept;
     static void ClearAllElements() noexcept;
@@ -162,8 +162,8 @@ public:
 
     static CInfoElement* GetRootElement() noexcept;
 
-    static HRESULT SaveElementAsImage(CInfoElement& element, REFGUID containerFormat, WICPixelFormatGUID& format, LPCWSTR filename, ICodeGenerator& codeGen);
-    static HRESULT CreateDecoderAndChildElements(LPCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem);
+    static HRESULT SaveElementAsImage(CInfoElement& element, REFGUID containerFormat, WICPixelFormatGUID& format, PCWSTR filename, ICodeGenerator& codeGen);
+    static HRESULT CreateDecoderAndChildElements(PCWSTR filename, ICodeGenerator& codeGen, CInfoElement*& decElem);
     static HRESULT CreateFrameAndChildElements(CInfoElement* parent, uint32_t index, IWICBitmapFrameDecode* frameDecode, ICodeGenerator& codeGen);
     static HRESULT CreateMetadataElementsFromBlock(CInfoElement* parent, IWICMetadataBlockReader* blockReader, ICodeGenerator& codeGen);
     static HRESULT CreateMetadataElements(CInfoElement* parent, uint32_t childIdx, IWICMetadataReader* reader, ICodeGenerator& codeGen);
@@ -178,7 +178,7 @@ private:
 class CComponentInfoElement : public CInfoElement
 {
 public:
-    explicit CComponentInfoElement(const LPCWSTR name)
+    explicit CComponentInfoElement(const PCWSTR name)
         : CInfoElement(name)
     {
     }
@@ -192,7 +192,7 @@ public:
 export class CBitmapDecoderElement final : public CComponentInfoElement
 {
 public:
-    explicit CBitmapDecoderElement(const LPCWSTR filename)
+    explicit CBitmapDecoderElement(const PCWSTR filename)
         : CComponentInfoElement(filename)
         , m_filename(filename)
     {
@@ -221,7 +221,7 @@ public:
     HRESULT OutputInfo(IOutputDevice& output) noexcept(false) override;
 
     void SetCreationTime(DWORD ms) noexcept;
-    void SetCreationCode(LPCWSTR code);
+    void SetCreationCode(PCWSTR code);
     void FillContextMenu(HMENU context) noexcept override;
 
 private:
@@ -235,7 +235,7 @@ private:
 export class CBitmapSourceElement : public CInfoElement
 {
 public:
-    CBitmapSourceElement(const LPCWSTR name, IWICBitmapSource* source)
+    CBitmapSourceElement(const PCWSTR name, IWICBitmapSource* source)
         : CInfoElement(name)
         , m_source(source)
     {

--- a/src/IOutputDevice.ixx
+++ b/src/IOutputDevice.ixx
@@ -20,15 +20,15 @@ public:
     virtual COLORREF SetTextColor(COLORREF color) = 0;
     virtual void SetHighlightColor(COLORREF color) noexcept(false) = 0;
 
-    virtual void SetFontName(LPCWSTR name) noexcept(false) = 0;
+    virtual void SetFontName(PCWSTR name) noexcept(false) = 0;
     virtual int SetFontSize(int pointSize) = 0;
 
-    virtual void BeginSection(LPCWSTR name) = 0;
-    virtual void AddText(LPCWSTR text) = 0;
-    virtual void AddVerbatimText(LPCWSTR text) = 0;
+    virtual void BeginSection(PCWSTR name) = 0;
+    virtual void AddText(PCWSTR text) = 0;
+    virtual void AddVerbatimText(PCWSTR text) = 0;
     virtual void AddDib(HGLOBAL hGlobal) = 0;
-    virtual void BeginKeyValues(LPCWSTR name) = 0;
-    virtual void AddKeyValue(LPCWSTR key, LPCWSTR value) = 0;
+    virtual void BeginKeyValues(PCWSTR name) = 0;
+    virtual void AddKeyValue(PCWSTR key, PCWSTR value) = 0;
     virtual void EndKeyValues() = 0;
     virtual void EndSection() = 0;
 };

--- a/src/ImageTransencoder.cpp
+++ b/src/ImageTransencoder.cpp
@@ -55,7 +55,7 @@ void CImageTransencoder::Clear() noexcept
     m_numPalettedFrames = 0;
 }
 
-HRESULT CImageTransencoder::Begin(REFGUID containerFormat, const LPCWSTR filename, ICodeGenerator &codeGen)
+HRESULT CImageTransencoder::Begin(REFGUID containerFormat, const PCWSTR filename, ICodeGenerator &codeGen)
 {
     HRESULT result = S_OK;
 
@@ -69,10 +69,7 @@ HRESULT CImageTransencoder::Begin(REFGUID containerFormat, const LPCWSTR filenam
     m_codeGen->CallFunction(L"imagingFactory->CreateStream(&stream);");
     IFC(g_imagingFactory->CreateStream(&m_stream));
 
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, solved in VS 2022, 17.5, but 17.5 has critical flaw in named modules]
     m_codeGen->CallFunction(std::format(L"stream->InitializeFromFilename(\"{}\", GENERIC_WRITE);", filename));
-#pragma warning(pop)
     IFC(m_stream->InitializeFromFilename(filename, GENERIC_WRITE));
 
     // Create the encoder

--- a/src/ImageTransencoder.ixx
+++ b/src/ImageTransencoder.ixx
@@ -20,7 +20,7 @@ public:
     CImageTransencoder& operator=(const CImageTransencoder&) = default;
     CImageTransencoder& operator=(CImageTransencoder&&) = default;
 
-    HRESULT Begin(REFCLSID containerFormat, LPCWSTR filename, ICodeGenerator &codeGen);
+    HRESULT Begin(REFCLSID containerFormat, PCWSTR filename, ICodeGenerator &codeGen);
     HRESULT AddFrame(IWICBitmapSource* bitmapSource);
     HRESULT SetThumbnail(IWICBitmapSource* thumb) const;
     HRESULT SetPreview(IWICBitmapSource* preview) const;

--- a/src/MainFrame.cpp
+++ b/src/MainFrame.cpp
@@ -239,7 +239,7 @@ void CMainFrame::UpdateTreeView(const bool selectLastRoot)
     }
 }
 
-HRESULT CMainFrame::OpenFile(const LPCWSTR filename, bool& updateElements)
+HRESULT CMainFrame::OpenFile(const PCWSTR filename, bool& updateElements)
 {
     updateElements = false;
 
@@ -258,27 +258,18 @@ HRESULT CMainFrame::OpenFile(const LPCWSTR filename, bool& updateElements)
 
         if (result == E_FAIL)
         {
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
             msg = std::format(L"File \"{}\" loaded but contained 0 frames.\n\n", filename);
-#pragma warning(pop)
         }
         else
         {
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
             msg = std::format(L"Unable to load the file \"{}\". The error is: {}.\n\n", filename, GetHresultString(result));
-#pragma warning(pop)
         }
 
         if (nullptr != newRoot)
         {
             updateElements = true;
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
             msg = std::format(L"Unable to completely load the file \"{}\". The error is: {}. Some parts of the file may still be viewed.\n\n",
                 filename, GetHresultString(result));
-#pragma warning(pop)
         }
 
         msg += codeGen.GenerateCode();
@@ -292,7 +283,7 @@ HRESULT CMainFrame::OpenFile(const LPCWSTR filename, bool& updateElements)
     return result;
 }
 
-HRESULT CMainFrame::OpenWildcard(const LPCWSTR search, DWORD& attempted, DWORD& opened, bool& updateElements)
+HRESULT CMainFrame::OpenWildcard(const PCWSTR search, DWORD& attempted, DWORD& opened, bool& updateElements)
 {
     updateElements = false;
     HRESULT hr = S_OK;
@@ -364,7 +355,7 @@ HRESULT CMainFrame::OpenWildcard(const LPCWSTR search, DWORD& attempted, DWORD& 
     return hr;
 }
 
-HRESULT CMainFrame::Load(const LPCWSTR* filenames, const int count)
+HRESULT CMainFrame::Load(const PCWSTR* filenames, const int count)
 {
     HRESULT result = S_OK;
     bool needsUpdate{};
@@ -457,7 +448,7 @@ LRESULT CMainFrame::OnFileOpen(uint16_t, uint16_t, const HWND hParentWnd, BOOL&)
     return 0;
 }
 
-HRESULT CMainFrame::OpenDirectory(const LPCWSTR directory, DWORD& attempted, DWORD& opened)
+HRESULT CMainFrame::OpenDirectory(const PCWSTR directory, DWORD& attempted, DWORD& opened)
 {
     HRESULT hr = S_OK;
     WIN32_FIND_DATA fdata;
@@ -595,7 +586,7 @@ LRESULT CMainFrame::OnTreeViewSelChanged(WPARAM /*wParam*/, const NMHDR* lpNmHdr
     return 0;
 }
 
-LRESULT CMainFrame::OnNMRClick(int, const LPNMHDR pnmh, BOOL&)
+LRESULT CMainFrame::OnNMRClick(int, NMHDR* pnmh, BOOL&)
 {
     // Get the location of the click point in the window
     POINT pt;

--- a/src/MainFrame.h
+++ b/src/MainFrame.h
@@ -50,7 +50,7 @@ public:
         CHAIN_MSG_MAP(CFrameWindowImpl<CMainFrame>)
     END_MSG_MAP()
 
-    HRESULT Load(const LPCWSTR *filenames, int count);
+    HRESULT Load(const PCWSTR *filenames, int count);
 
 private:
     InfoElementViewContext m_viewcontext{false, true};
@@ -58,11 +58,11 @@ private:
     HWND CreateClient();
     static int GetElementTreeImage(const CInfoElement *elem) noexcept;
     // Opens a single file
-    HRESULT OpenFile(LPCWSTR filename, bool &updateElements);
+    HRESULT OpenFile(PCWSTR filename, bool &updateElements);
     // Opens files based on a wildcard expression (not recursive)
-    HRESULT OpenWildcard(LPCWSTR search, DWORD &attempted, DWORD &opened, bool &updateElements);
+    HRESULT OpenWildcard(PCWSTR search, DWORD &attempted, DWORD &opened, bool &updateElements);
     // Opens images recursively in a directory
-    HRESULT OpenDirectory(LPCWSTR directory, DWORD &attempted, DWORD &opened);
+    HRESULT OpenDirectory(PCWSTR directory, DWORD &attempted, DWORD &opened);
     void UpdateTreeView(bool selectLastRoot);
     HTREEITEM BuildTree(const CInfoElement *elem, HTREEITEM hParent);
     static BOOL DoElementContextMenu(HWND hWnd, CInfoElement &element, POINT point) noexcept;
@@ -76,7 +76,7 @@ private:
     HRESULT QueryMetadata(CInfoElement* elem);
 
     LRESULT OnCreate(uint32_t, WPARAM, LPARAM, BOOL&);
-    LRESULT OnNMRClick(int , LPNMHDR pnmh, BOOL&);
+    LRESULT OnNMRClick(int , NMHDR* pnmh, BOOL&);
     LRESULT OnTreeViewSelChanged(WPARAM wParam, const NMHDR* lpNmHdr, BOOL &bHandled);
     LRESULT OnPaneClose(uint16_t, uint16_t, HWND hWndCtl, BOOL&) const;
     LRESULT OnFileOpen(uint16_t, uint16_t, HWND, BOOL&);

--- a/src/MetadataTranslator.cpp
+++ b/src/MetadataTranslator.cpp
@@ -131,7 +131,7 @@ HRESULT CMetadataTranslator::LoadFormat(MSXML2::IXMLDOMNode* formatNodeArg)
                     _bstr_t valueStr{entryValueNode->nodeValue};
 
                 // Finally, we can add this entry
-                m_dictionary.push_back(std::make_pair(Key(formatGuidStr, idStr), static_cast<LPCWSTR>(valueStr)));
+                m_dictionary.push_back(std::make_pair(Key(formatGuidStr, idStr), static_cast<PCWSTR>(valueStr)));
             }
         }
     }

--- a/src/OutputDevice.cpp
+++ b/src/OutputDevice.cpp
@@ -14,8 +14,8 @@ import Util;
 
 namespace {
 
-LPCWSTR NormalFontName = L"Verdana";
-LPCWSTR VerbatimFontName = L"Lucida Console";
+PCWSTR NormalFontName = L"Verdana";
+PCWSTR VerbatimFontName = L"Lucida Console";
 
 constexpr auto TEXT_SIZE{10};
 
@@ -60,7 +60,7 @@ void CRichEditDevice::SetHighlightColor(const COLORREF color) noexcept(false)
     m_richEditCtrl.SendMessage(EM_SETCHARFORMAT, SCF_SELECTION | SCF_WORD, reinterpret_cast<LPARAM>(&cf));
 }
 
-void CRichEditDevice::SetFontName(const LPCWSTR name) noexcept(false)
+void CRichEditDevice::SetFontName(const PCWSTR name) noexcept(false)
 {
     CHARFORMAT2 cf{{.cbSize = sizeof cf}, FW_NORMAL};
 
@@ -92,7 +92,7 @@ int CRichEditDevice::SetFontSize(const int pointSize)
     return result;
 }
 
-void CRichEditDevice::BeginSection(const LPCWSTR name)
+void CRichEditDevice::BeginSection(const PCWSTR name)
 {
     // Add this new level to the output stack
     m_sections.push_back(std::wstring{name});
@@ -115,12 +115,12 @@ void CRichEditDevice::BeginSection(const LPCWSTR name)
     }
 }
 
-void CRichEditDevice::AddText(const LPCWSTR name)
+void CRichEditDevice::AddText(const PCWSTR name)
 {
     m_richEditCtrl.AppendText(name);
 }
 
-void CRichEditDevice::AddVerbatimText(const LPCWSTR name)
+void CRichEditDevice::AddVerbatimText(const PCWSTR name)
 {
     SetFontName(VerbatimFontName);
     m_richEditCtrl.AppendText(name);
@@ -129,7 +129,7 @@ void CRichEditDevice::AddVerbatimText(const LPCWSTR name)
 
 void CRichEditDevice::AddDib(const HGLOBAL hBitmap)
 {
-    IRichEditOle* oleInterface = m_richEditCtrl.GetOleInterface();
+    IRichEditOle* oleInterface{m_richEditCtrl.GetOleInterface()};
 
     if (oleInterface)
     {
@@ -137,12 +137,9 @@ void CRichEditDevice::AddDib(const HGLOBAL hBitmap)
 
         if (FAILED(result))
         {
-            const COLORREF oldColor = SetTextColor(RGB(255, 0, 0));
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
+            const COLORREF oldColor{SetTextColor(RGB(255, 0, 0))};
             AddText(std::format(L"Failed to render bitmap: {}\n", GetHresultString(result)).c_str());
             SetTextColor(oldColor);
-#pragma warning(pop)
         }
         else
         {
@@ -153,7 +150,7 @@ void CRichEditDevice::AddDib(const HGLOBAL hBitmap)
     }
 }
 
-void CRichEditDevice::BeginKeyValues(const LPCWSTR name)
+void CRichEditDevice::BeginKeyValues(const PCWSTR name)
 {
     // Write the heading if one was specified
     if ((nullptr != name) && (L'\0' != *name))
@@ -168,7 +165,7 @@ void CRichEditDevice::BeginKeyValues(const LPCWSTR name)
     }
 }
 
-void CRichEditDevice::AddKeyValue(const LPCWSTR key, const LPCWSTR value)
+void CRichEditDevice::AddKeyValue(const PCWSTR key, const PCWSTR value)
 {
     const COLORREF oldColor = SetTextColor(RGB(0, 128, 0));
 

--- a/src/OutputDevice.ixx
+++ b/src/OutputDevice.ixx
@@ -23,15 +23,15 @@ public:
     COLORREF SetTextColor(COLORREF color) override;
     void SetHighlightColor(COLORREF color) noexcept(false) override;
 
-    void SetFontName(LPCWSTR name) noexcept(false) override;
+    void SetFontName(PCWSTR name) noexcept(false) override;
     int SetFontSize(int pointSize) override;
 
-    void BeginSection(LPCWSTR name) override;
-    void AddText(LPCWSTR name) override;
-    void AddVerbatimText(LPCWSTR name) override;
+    void BeginSection(PCWSTR name) override;
+    void AddText(PCWSTR name) override;
+    void AddVerbatimText(PCWSTR name) override;
     void AddDib(HGLOBAL hBitmap) override;
-    void BeginKeyValues(LPCWSTR name) override;
-    void AddKeyValue(LPCWSTR key, LPCWSTR value) override;
+    void BeginKeyValues(PCWSTR name) override;
+    void AddKeyValue(PCWSTR key, PCWSTR value) override;
     void EndKeyValues() override;
     void EndSection() noexcept override;
 

--- a/src/PropVariant.cpp
+++ b/src/PropVariant.cpp
@@ -19,7 +19,7 @@ template<class T> static void WriteValue(const T& /*val*/, std::wstring& out)
     out = L"<UnknownValue>";
 }
 
-template<class T> static LPCWSTR GetTypeName()
+template<class T> static PCWSTR GetTypeName()
 {
     return L"<UnknownType>";
 }
@@ -44,19 +44,19 @@ template<> PCWSTR GetTypeName<UCHAR>() noexcept
     return L"UCHAR";
 }
 
-template<> void WriteValue<SHORT>(const SHORT& val, std::wstring& out)
+template<> void WriteValue<short>(const short& val, std::wstring& out)
 {
     out = std::format(L"{}", static_cast<int>(val));
 }
 
-template<> PCWSTR GetTypeName<SHORT>() noexcept
+template<> PCWSTR GetTypeName<short>() noexcept
 {
     return L"SHORT";
 }
 
-template<> void WriteValue<USHORT>(const USHORT& val, std::wstring& out)
+template<> void WriteValue<unsigned short>(const unsigned short& val, std::wstring& out)
 {
-    out = std::format(L"{}", static_cast<unsigned>(val));
+    out = std::format(L"{}", val);
 }
 
 template<> PCWSTR GetTypeName<USHORT>() noexcept
@@ -64,32 +64,32 @@ template<> PCWSTR GetTypeName<USHORT>() noexcept
     return L"USHORT";
 }
 
-template<> void WriteValue<LONG>(const LONG& val, std::wstring& out)
+template<> void WriteValue<long>(const long& val, std::wstring& out)
 {
     out = std::format(L"{}", static_cast<int>(val));
 }
 
-template<> PCWSTR GetTypeName<LONG>() noexcept
+template<> PCWSTR GetTypeName<long>() noexcept
 {
     return L"LONG";
 }
 
-template<> void WriteValue<ULONG>(const ULONG& val, std::wstring& out)
+template<> void WriteValue<unsigned long>(const unsigned long& val, std::wstring& out)
 {
     out = std::format(L"{}", static_cast<unsigned>(val));
 }
 
-template<> PCWSTR GetTypeName<ULONG>() noexcept
+template<> PCWSTR GetTypeName<unsigned long>() noexcept
 {
     return L"ULONG";
 }
 
-template<> void WriteValue<INT>(const INT& val, std::wstring& out)
+template<> void WriteValue<int>(const int& val, std::wstring& out)
 {
     out = std::format(L"{}", static_cast<int>(val));
 }
 
-template<> PCWSTR GetTypeName<INT>() noexcept
+template<> PCWSTR GetTypeName<int>() noexcept
 {
     return L"INT";
 }
@@ -140,22 +140,22 @@ template<> PCWSTR GetTypeName<ULARGE_INTEGER>() noexcept
     return L"ULARGE_INTEGER";
 }
 
-template<> void WriteValue<FLOAT>(const FLOAT& val, std::wstring& out)
+template<> void WriteValue<float>(const float& val, std::wstring& out)
 {
     out = std::to_wstring(val).c_str();
 }
 
-template<> PCWSTR GetTypeName<FLOAT>() noexcept
+template<> PCWSTR GetTypeName<float>() noexcept
 {
     return L"FLOAT";
 }
 
-template<> void WriteValue<DOUBLE>(const DOUBLE& val, std::wstring& out)
+template<> void WriteValue<double>(const double& val, std::wstring& out)
 {
     out = std::to_wstring(val).c_str();
 }
 
-template<> PCWSTR GetTypeName<DOUBLE>() noexcept
+template<> PCWSTR GetTypeName<double>() noexcept
 {
     return L"DOUBLE";
 }
@@ -217,7 +217,7 @@ template<> PCWSTR GetTypeName<PSTR>() noexcept
     return L"PSTR";
 }
 
-template<> void WriteValue<LPWSTR>(const LPWSTR& val, std::wstring& out)
+template<> void WriteValue<PWSTR>(const PWSTR& val, std::wstring& out)
 {
     out = L"\"" + std::wstring(val) + L"\"";
 }

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -63,7 +63,7 @@ constexpr array g_wicErrorCodes{
 std::wstring GetHresultString(HRESULT hr)
 {
     const auto knownError = std::find_if(g_wicErrorCodes.begin(), g_wicErrorCodes.end(),
-        [=](const pair<HRESULT, LPCWSTR>& x) { return x.first == hr; });
+        [=](const pair<HRESULT, PCWSTR>& x) { return x.first == hr; });
 
     if (FACILITY_WINCODEC_ERR == HRESULT_FACILITY(hr) && knownError != g_wicErrorCodes.end())
     {
@@ -98,8 +98,5 @@ std::wstring GetHresultString(HRESULT hr)
         return msg;
     }
 
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false [known problem in MSVC/STL, solved in VS 2022, 17.5, but 17.5 has critical flaw in named modules]
     return std::format(L"{:#8X}", hr);
-#pragma warning(pop)
 }

--- a/src/WICExplorer.cpp
+++ b/src/WICExplorer.cpp
@@ -26,7 +26,7 @@ import <std.h>;
 
 
 
-int Run(CAppModule& appModule, const LPCWSTR lpCmdLine, const int nCmdShow)
+int Run(CAppModule& appModule, const PCWSTR lpCmdLine, const int nCmdShow)
 {
     CMessageLoop msgLoop;
     appModule.AddMessageLoop(&msgLoop);
@@ -46,7 +46,7 @@ int Run(CAppModule& appModule, const LPCWSTR lpCmdLine, const int nCmdShow)
 
     // Load the files
     int argc;
-    LPWSTR* argv = CommandLineToArgvW(lpCmdLine, &argc);
+    PWSTR* argv = CommandLineToArgvW(lpCmdLine, &argc);
 
     // If argc == 0, then lpCmdLine is the name of the executable (WICExplorer)
     if (*lpCmdLine != 0)
@@ -68,7 +68,7 @@ int Run(CAppModule& appModule, const LPCWSTR lpCmdLine, const int nCmdShow)
 
 WARNING_SUPPRESS_NEXT_LINE(26461) // The pointer argument 'lpCmdLine' for function 'wWinMain' can be marked as a pointer to const (con.3).
 _Use_decl_annotations_
-int WINAPI wWinMain(const HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, const LPWSTR lpCmdLine, const int nShowCmd)
+int WINAPI wWinMain(const HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, const PWSTR lpCmdLine, const int nShowCmd)
 {
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 
@@ -95,11 +95,8 @@ int WINAPI wWinMain(const HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, cons
     ATLASSERT(SUCCEEDED(hr));
     if (FAILED(hr))
     {
-#pragma warning(push)
-#pragma warning(disable : 4296) // '<': expression is always false
         MessageBoxW(nullptr, std::format(L"Unable to create ImagingFactory. The error is: {}.", GetHresultString(hr)).c_str(),
             L"Error Creating ImagingFactory", MB_ICONERROR);
-#pragma warning(pop)
     }
 
     // Initialize the RichEdit library


### PR DESCRIPTION
Replace the lecacy 'L' prefix with the typedefs without the L.
The concept of FAR pointers doesn't apply in x86 and x64 Win32 API.